### PR TITLE
added WalletNameLookup function to resolve addresses given a netki na…

### DIFF
--- a/netki.go
+++ b/netki.go
@@ -27,6 +27,30 @@ func (e NetkiError) Error() string {
 	return buffer.String()
 }
 
+// WalletNameLookup resolves an address from a netki address and currency.
+func WalletNameLookup(uri, currency string) (string, error) {
+	apimethod := "https://pubapi.netki.com/api/wallet_lookup"
+	resp, err := http.Get(fmt.Sprintf("%s/%s/%s", apimethod, uri, currency))
+	if err != nil {
+		return "", err
+	}
+
+	j, err := simplejson.NewFromReader(resp.Body)
+	if err != nil {
+		return "", err
+	} else if resp.StatusCode != 200 {
+		return "", fmt.Errorf("Could not resolve netki address")
+	}
+	
+	if msg, err := j.Get("message").String(); msg != "" {
+		return "", fmt.Errorf(msg)
+	} else if err != nil {
+		return "", err
+	}
+	
+	return j.Get("wallet_address").String()
+}
+
 type Partner struct {
 	id, partnerName string
 }

--- a/netki_test.go
+++ b/netki_test.go
@@ -690,3 +690,34 @@ func TestGetWalletNamesZeroWalletCount(t *testing.T) {
 
 	assert.Equal(t, 0, len(wns))
 }
+
+func TestWalletNameLookup(t *testing.T) {
+	uri := "wallet.mattdavid.xyz"
+	currency := "btc"
+	s, err := WalletNameLookup(uri, currency)
+	if err != nil {
+		t.Error(err)
+	}
+	t.Log("Address:", s)
+}
+
+func TestWalletNameLookupBadname(t *testing.T) {
+	uri := "badbad"
+	currency := "btc"
+	s, err := WalletNameLookup(uri, currency)
+	if err == nil {
+		t.Error("Got no error on bad currency")
+	}
+	t.Log("Address:", s)
+}
+
+func TestWalletNameLookupBadCurrency(t *testing.T) {
+	uri := "wallet.mattdavid.xyz"
+	currency := "badbad"
+	s, err := WalletNameLookup(uri, currency)
+	if err == nil {
+		t.Error("Got no error on bad currency")
+	}
+	t.Log("Address:", s)
+}
+


### PR DESCRIPTION
I did not use the assert package github.com/bmizerany/assert in my test cases as with your other tests, so you will probably want to update the tests to conform to your policies. I named the function after the api call. The function returns (string, error) instead of netki.Wallet or netki.NetkiError, my thinking is that this function needs to be used generically by external applications that may not need to know about the Netki data structures.